### PR TITLE
feat(skills): add self-evaluation and execution skills + skill creation guide

### DIFF
--- a/.github/SKILL_CREATION_GUIDE.md
+++ b/.github/SKILL_CREATION_GUIDE.md
@@ -1,0 +1,183 @@
+# Creating New Agent Skills
+
+Guidelines for creating new skills that follow the agentskills.io specification and work with GitHub Copilot.
+
+---
+
+## Quick Checklist
+
+Before creating a skill, ensure you can answer:
+- [ ] **What does this skill do?** (one sentence)
+- [ ] **When should it activate?** (specific triggers/keywords)
+- [ ] **What problem does it solve?** (user need)
+- [ ] **Is this better as a skill vs inline instructions?** (reusable pattern?)
+
+---
+
+## Skill Structure
+
+```
+.github/skills/
+└── your-skill-name/
+    ├── SKILL.md                    # Required: Main instructions for agent
+    └── references/                 # Optional: Additional context loaded on-demand
+        ├── REFERENCE.md
+        └── EXAMPLES.md
+```
+
+**Do NOT create:**
+- `scripts/` directory
+- `assets/` directory (unless absolutely necessary)
+- Multiple skill files (one `SKILL.md` per skill)
+
+---
+
+## SKILL.md Format
+
+### Frontmatter (Required)
+
+```yaml
+---
+name: your-skill-name
+description: >
+  Brief description of what the skill does and when to use it.
+  Include specific keywords that trigger this skill. Max 1024 characters.
+license: CC0-1.0
+metadata:
+  author: JPEGtheDev
+  version: "1.0"
+  category: [e.g., recipe, validation, meta, ci]
+  project: OpenCookbook
+---
+```
+
+**Name Rules:**
+- Lowercase only, 1–64 characters
+- Use hyphens (`-`) not underscores or spaces
+- No leading/trailing or consecutive hyphens
+- Must match parent directory name
+
+**Description Rules:**
+- 1–1024 characters
+- Include "what" and "when"
+- Use keywords agents will search for
+
+### Body Content
+
+**Key Principles:**
+1. **Write for the AI agent, not humans** — use imperative: "Do this", "Check that"
+2. **Be conversational first** — instruct the agent to ask questions before acting
+3. **Provide clear workflows** — numbered steps or clear sections
+4. **Include examples** — show expected behavior and edge cases
+
+**Recommended Sections:**
+
+```markdown
+# Instructions for Agent
+
+## How This Skill is Invoked
+[How users activate this skill]
+
+## When to Use This Skill
+[Specific triggers and contexts]
+
+## Step 1: [First Action]
+[Detailed instructions]
+
+## Step 2: [Next Action]
+[More instructions]
+
+## Common Edge Cases
+[How to handle vague requests, errors, etc.]
+```
+
+---
+
+## Progressive Disclosure
+
+Skills should load context efficiently:
+
+| Layer | Token Budget | What Goes Here |
+|-------|-------------|----------------|
+| Frontmatter | ~100 tokens | Name, description, keywords |
+| SKILL.md body | <5000 tokens | Core workflow, examples, key rules |
+| References | On-demand | Detailed frameworks, lengthy examples, project-specific data |
+
+**Keep SKILL.md under 500 lines.** Move detailed reference material to `references/`.
+
+---
+
+## Writing Agent Instructions
+
+### ✅ Good: Imperative, Agent-Focused
+```markdown
+## Step 1: Gather Requirements
+
+Ask the user clarifying questions conversationally:
+
+> "I'd love to help with that! A few quick questions:
+> 1. What problem are you trying to solve?
+> 2. What's the scope — small fix or larger restructure?"
+
+**Allow them to skip questions** — use sensible defaults if they say "just go".
+```
+
+### ❌ Bad: User-Facing Documentation
+```markdown
+## How to Use This Skill
+
+To use this skill, provide the following information to Copilot:
+1. Your requirements
+2. The scope of work
+
+The skill will then generate output for you.
+```
+
+---
+
+## Anti-Patterns
+
+| ❌ Don't | ✅ Do Instead |
+|---|---|
+| Collect 10 inputs via a form | Start a conversation, ask 2–3 questions |
+| Generate with rigid template | Generate based on context, allow overrides |
+| Over-specify implementation | Focus on outcomes, let agent choose approach |
+| Include all references in SKILL.md | Link to `references/`, load on-demand |
+| Duplicate content across skills | Cross-reference other skills |
+
+---
+
+## Version Management
+
+When updating skills:
+
+1. **Increment version** in frontmatter metadata
+2. **Document the reason** — what changed and why
+3. **Keep backward compatible** when possible
+
+Version bumps:
+- Minor fix/addition: `"1.0"` → `"1.1"`
+- Major restructure: `"1.1"` → `"2.0"`
+
+---
+
+## Registering a New Skill
+
+After creating a skill:
+
+1. **Add it to the Skills Directory** in [copilot-instructions.md](copilot-instructions.md)
+2. **Add it to the Minimum Skill Loads table** if it applies to specific task types
+3. **Add a description entry** in the VS Code skills configuration (`.github/copilot-instructions.md` skills section)
+
+---
+
+## Summary: The Perfect Skill
+
+✅ **Clear activation triggers** in description
+✅ **Conversational approach** — asks before generating
+✅ **Allows overrides** — user control at every step
+✅ **Progressive disclosure** — uses references efficiently
+✅ **Under 500 lines** in SKILL.md
+✅ **Focused and specific** — does ONE thing well
+✅ **Agent-focused instructions** — not user docs
+✅ **Versioned** — frontmatter tracks changes

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -109,8 +109,25 @@ This repository has detailed skill files. **Read the right skill BEFORE starting
 | Write a user story using the INVEST framework | [user-stories](skills/user-stories/SKILL.md) |
 | Fill in a PR description or title | [pull-request](skills/pull-request/SKILL.md) |
 | Write or edit a GitHub Actions workflow | [ci-workflows](skills/ci-workflows/SKILL.md) |
+| Execute any non-trivial implementation work | [execution](skills/execution/SKILL.md) |
+| End-of-session review and lessons learned | [self-evaluation](skills/self-evaluation/SKILL.md) |
 
 If you don't know which skill to use, read **recipe-documentation** — it has the format rules.
+
+### Minimum Skill Loads by Task Type
+
+These are **mandatory** — not suggestions. Load these skills before starting the listed task.
+
+| If the task involves… | MUST read these skills |
+|---|---|
+| Any multi-step implementation work | `execution` |
+| Creating or editing a recipe | `execution`, `recipe-documentation` |
+| Creating a new recipe from scratch | `execution`, `recipe-creation`, `recipe-documentation` |
+| Validating a recipe | `recipe-validation` |
+| Writing or editing C#/Blazor code | `execution` |
+| Creating a PR or commit | `recipe-versioning` |
+| CI/CD or workflow changes | `ci-workflows` |
+| End of session (always) | `self-evaluation` |
 
 ---
 
@@ -123,6 +140,25 @@ Do these steps **in this exact order**. Do not skip any. These are not suggestio
 3. **Read the skill.** Open the correct skill file from the table above and read the ENTIRE file. Do not skim. Do not summarize. Read every line. The skill contains rules you must follow.
 4. **Plan before building.** If the task has 3+ steps or involves any structural decision, write out a numbered step-by-step plan BEFORE doing anything. Show the plan. If something goes wrong mid-plan, STOP immediately and write a new plan. Do not push forward on a broken approach.
 5. **Ask if unsure.** If any detail is ambiguous, missing, or could be interpreted two ways, STOP and ask the user before proceeding. Do not guess. Do not assume. Do not fill in blanks with plausible values.
+6. **Use a todo list.** For every task, use `manage_todo_list` to plan your work. Mark items in-progress before starting, completed immediately after finishing. This makes progress visible and ensures nothing is forgotten.
+
+---
+
+## After You Finish Any Task (Session Lifecycle)
+
+**Before your final message to the user**, you MUST do all of the following:
+
+1. **Read** the [self-evaluation skill](skills/self-evaluation/SKILL.md) and follow its steps.
+2. **Identify lessons learned** — mistakes made, user corrections, patterns discovered.
+3. **Check existing skills** — is the lesson already documented? If yes, skip.
+4. **Apply updates** — for High/Medium priority lessons, update the relevant skill file and bump its version in the YAML frontmatter.
+5. **Report** — include a brief `### Session Self-Evaluation` block in your final message:
+   ```
+   ### Session Self-Evaluation
+   Lessons: [count] | Skills updated: [list or "None"] | Compacted: [files or "None"]
+   ```
+
+If you have nothing to report, still include the block with zeroes. This ensures the behavior is habitual.
 
 ---
 

--- a/.github/lessons.md
+++ b/.github/lessons.md
@@ -25,6 +25,11 @@ record; the skills and instructions are where rules live and get enforced.
 
 ## Log
 
+### 2026-03-15 — Include self‑evaluation section at end of every response
+
+**What happened:** I responded without a consistent self‑evaluation format and the user pointed out the missing behavior.
+**Absorbed into:** copilot-instructions → Working Principles ("You finish a response to the user → Add a self‑evaluation section...").
+
 ### 2026-03-14 — Verify state before assuming blockers
 
 **What happened:** Assumed PR review conversations were still unresolved without checking.

--- a/.github/skills/ci-workflows/SKILL.md
+++ b/.github/skills/ci-workflows/SKILL.md
@@ -187,7 +187,7 @@ For deploy jobs, use `cancel-in-progress: false`.
 
 See `.github/workflows/pr-build.yml`. Triggers on `pull_request` targeting `main`. Runs full build/test pipeline, uploads the built site as an artifact, and posts a PR comment with download instructions.
 
-**Artifact-based PR preview approach:** The built site (including `scripts/serve.py`) is uploaded as a GitHub Actions artifact named `pr-preview-site`. The PR comment posts both a `gh` CLI command and a `curl` one-liner so reviewers can download and serve the site locally with `python3 serve.py`. This avoids overwriting the production GitHub Pages site.
+**Artifact-based PR preview approach:** The built site (including `scripts/serve.py`) is uploaded as a GitHub Actions artifact named `pr-preview-site`. The PR comment posts a `gh` CLI command (including `-D pr-preview-site` so the artifact extracts into a known folder) and a `curl` one-liner so reviewers can download and serve the site locally with `python3 serve.py` from the extracted directory. This avoids overwriting the production GitHub Pages site.
 
 **Key points:**
 - Permissions: `contents: read` + `pull-requests: write` only. No `pages: write` or `id-token: write` needed.

--- a/.github/skills/execution/SKILL.md
+++ b/.github/skills/execution/SKILL.md
@@ -1,0 +1,243 @@
+````skill
+---
+name: execution
+description: Autonomous execution protocol for implementing tasks. Governs planning, iteration, subagent use, verification, and self-correction. Use when executing any non-trivial implementation work — recipe edits, code changes, CI/CD updates, or multi-step tasks.
+license: CC0-1.0
+metadata:
+  author: JPEGtheDev
+  version: "1.0"
+  category: execution
+  project: OpenCookbook
+---
+
+# Execution
+
+## How This Skill is Invoked
+
+This skill is **mandatory for all implementation work**. `copilot-instructions.md` requires it for any task involving file changes, multi-step work, or structural decisions. Read it before starting.
+
+---
+
+## Core Principles
+
+These govern every decision during execution:
+
+- **Keep It Simple:** Prefer the straightforward approach. Only introduce complexity when it earns its place.
+- **Surgical Precision:** Touch only what the task requires. A smaller diff is almost always a better diff.
+- **Drive to Completion:** Act on what you know. Resolve blockers yourself. Don't wait for permission to fix obvious problems.
+- **Never Guess:** In a recipe repo, wrong data is worse than no data. If you don't know a value, ask.
+
+---
+
+## Phase 1: Scope and Sequence
+
+**Establish a clear plan before making changes** whenever the task involves 3+ steps or any structural judgment.
+
+### Decision Table
+
+| Situation | Response |
+|---|---|
+| Single-file, obvious fix | Implement immediately — no ceremony needed |
+| Changes spanning multiple files | Outline the sequence first |
+| Structural or format decisions | Specify the approach before touching files |
+| Ambiguous requirements | Research first (subagents are cheap) |
+| User story with acceptance criteria | Decompose criteria into ordered checkpoints |
+
+### Building the Plan
+
+1. **Create a todo list** (`manage_todo_list`) with concrete, verifiable items
+2. **Specify expected changes** up front — which files, what kind of edit
+3. **Bake in proof steps** — plan how you will verify each change (validation checklist, build, etc.)
+4. **Sanity-check coverage** — does the plan address every requirement?
+5. **Abandon broken plans early** — if progress stalls, scrap the approach and redesign
+
+---
+
+## Phase 2: Disciplined Iteration
+
+### The Work Loop
+
+For every planned item:
+
+```
+1. Flag it as in-progress
+2. Make the change
+3. Prove it works (validate, build, inspect diff)
+4. Flag it as done
+5. Commit when you reach a logical boundary
+6. Advance to the next item
+```
+
+**A task is not done until you can demonstrate it works.** That means:
+- File is valid YAML (for recipes)
+- Validation checklist passes (for recipe edits)
+- Build succeeds (for code changes)
+- Tests pass (if applicable)
+- You would confidently submit this for review
+
+### Communicating Progress
+
+- Summarize at the milestone level, not the keystroke level
+- State what changed, what was validated, and what comes next
+- When all items are complete, give a brief accounting of files touched, tests run, and notable decisions
+
+### Commit Rhythm
+
+- One commit per logical unit — not per file, not per session
+- Every commit must be valid on its own (no half-finished states)
+- Follow conventional commit format (see `recipe-versioning` skill)
+- Never lump unrelated changes together
+
+---
+
+## Phase 3: Delegating to Subagents
+
+Preserve your context window by offloading research and exploration.
+
+### Good Candidates for Delegation
+
+| Work | Delegate? |
+|---|---|
+| Exploring recipe patterns across the repo | Yes |
+| Scanning for broken cross-references | Yes |
+| Reading multiple skill files for context | Yes |
+| Making a single targeted edit | No — do this inline |
+| Investigating CI failures or build errors | Yes |
+
+### Delegation Guidelines
+
+- **One clear objective per subagent** — focused tasks yield better results
+- **State the return format** — tell it exactly what information you need back
+- **Accept the findings** unless they conflict with verified facts
+- Subagents gather information; you apply it
+
+---
+
+## Phase 4: Prove It Before You Ship It
+
+**Completion requires evidence, not just intent.**
+
+### For Recipe Changes
+
+- [ ] **Valid YAML:** No syntax errors
+- [ ] **Validation checklist:** Run the full recipe-validation skill checklist
+- [ ] **Cross-references valid:** All `path` values in `related[]` point to real files
+- [ ] **Diff inspected:** `git diff` — read every hunk for accidental changes
+
+### For Code Changes (Visualizer)
+
+- [ ] **Builds:** `dotnet build`
+- [ ] **Tests green:** `dotnet test`
+- [ ] **Diff inspected:** `git diff` — no unintended changes
+
+### For CI/Workflow Changes
+
+- [ ] **Valid YAML syntax** — no indentation errors
+- [ ] **Correct action versions** — pinned to specific versions
+- [ ] **Diff inspected:** only intended changes present
+
+### Universal
+
+- [ ] **No trusted silence:** Empty tool output gets a second verification method
+- [ ] **Review-ready:** You would not hesitate to open a PR with this
+
+---
+
+## Phase 5: Pursue Clarity
+
+After something works but before you commit, pause: **"Is there a cleaner way to express this?"**
+
+### Apply When
+
+- A working solution feels convoluted
+- Hindsight reveals a simpler path
+- Nearby content could be simplified without expanding scope
+
+### Skip When
+
+- The fix is already obvious and direct
+- The change is purely mechanical
+- Improvement would require unrelated restructuring
+
+---
+
+## Phase 6: Resolve Errors Autonomously
+
+When you encounter a failing build, broken YAML, validation error, or CI failure: **resolve it without prompting.**
+
+### Approach
+
+1. **Parse the failure** — read the actual error, not just the summary
+2. **Reproduce locally** — run the same command that failed
+3. **Trace to the root** — don't mask symptoms with patches
+4. **Implement the fix** — choose the correct solution, not the fastest one
+5. **Confirm resolution** — prove the error no longer occurs
+6. **Scan for siblings** — check whether the same pattern exists elsewhere
+
+### Prohibited Behaviors
+
+- Asking whether you should fix an obvious error — of course you should
+- Describing a problem without working toward a solution
+- Presenting a menu of options instead of executing the best one
+- Pushing diagnosis work back to the user
+- Settling for a workaround when a proper fix is reachable
+
+---
+
+## Phase 7: Continuous Skill Refinement
+
+**Correct course in real time, not just at session end.**
+
+After any mistake or user correction during a session:
+
+1. **Name the failure mode** — what exactly went wrong?
+2. **Search existing skills** — is this already documented?
+3. **If it's new, update the relevant skill now** — don't defer to the end-of-session review
+4. **Write a concrete prevention rule** — vague advice doesn't prevent recurrence
+
+This complements the mandatory end-of-session self-evaluation. The difference: this happens the moment you learn something, not after the work is finished.
+
+---
+
+## Prohibited Patterns
+
+These behaviors are explicitly disallowed:
+
+1. **Waiting for a green light** — if the task is defined, begin executing
+2. **Surfacing problems without fixes** — always pair a diagnosis with a resolution
+3. **Declaring done without proof** — every completion claim needs supporting evidence
+4. **Doubling down on a stuck approach** — halt, rethink, restart
+5. **Gold-plating simple work** — match effort to actual complexity
+6. **Winging complex work** — multi-step tasks get a written plan
+7. **Walking past defects** — if you spot an issue while working, address or log it
+8. **Believing empty output** — always cross-check with a second method
+9. **Guessing data values** — in a recipe repo, wrong quantities are dangerous. Ask.
+
+---
+
+## Quick Reference
+
+```
+Task arrives
+    ↓
+Trivial (1-2 steps)?
+    Yes → Implement, verify, commit
+    No  ↓
+Plan: build todo list with verifiable items
+    ↓
+Per item:
+    Start → Implement → Prove → Complete → Commit
+    ↓
+    Stuck? → Stop → Re-plan → Resume
+    ↓
+All done?
+    ↓
+Final gate:
+    Valid ✓ | Validated ✓ | Diff clean ✓ | Review-ready ✓
+    ↓
+Self-evaluate (per self-evaluation skill)
+    ↓
+Ship it
+```
+
+````

--- a/.github/skills/self-evaluation/SKILL.md
+++ b/.github/skills/self-evaluation/SKILL.md
@@ -1,0 +1,136 @@
+````skill
+---
+name: self-evaluation
+description: End-of-session self-evaluation for continuous improvement. Run before finalizing any session to capture lessons learned, identify skill updates, and improve agent effectiveness. Use when completing a task, reviewing work quality, or improving project skills.
+license: CC0-1.0
+metadata:
+  author: JPEGtheDev
+  version: "1.0"
+  category: meta
+  project: OpenCookbook
+---
+
+# Self-Evaluation
+
+## How This Skill is Invoked
+
+This skill is **mandatory** — `copilot-instructions.md` § Session Lifecycle requires it before every final message. You will also be invoked:
+- When explicitly asked: "Run self-evaluation", "What did you learn?", "Improve skills"
+- After addressing review feedback that reveals a recurring pattern
+
+---
+
+## Core Principle: Learn From Every Session
+
+Every session produces insights that can improve future agent effectiveness. Capture these systematically — don't let knowledge evaporate between sessions. This is how skills stay current.
+
+---
+
+## Step 1: Review the Session
+
+Examine what happened during this session:
+
+1. **User corrections received** — Did the user correct you? What was wrong?
+2. **Mistakes made and self-corrected** — Did you catch your own errors? How?
+3. **Patterns discovered** — Did a reusable pattern emerge from the work?
+4. **Rules you almost broke** — Did you catch a near-miss on one of the 5 Rules or a Working Principle?
+5. **Review/PR feedback** — Were there comments on a PR that reveal a gap?
+
+---
+
+## Step 2: Categorize Lessons
+
+Classify each lesson by where it belongs:
+
+| Category | Examples | Update Target |
+|----------|----------|---------------|
+| **Recipe format** | Missing `volume_alt`, wrong units, missing field | `recipe-documentation` skill |
+| **Recipe validation** | New error pattern, missing checklist item | `recipe-validation` skill |
+| **Recipe creation** | Conversation flow issue, gathering gaps | `recipe-creation` skill |
+| **Versioning** | Commit format, version bump rules | `recipe-versioning` skill |
+| **CI/CD** | Workflow structure, deploy issues | `ci-workflows` skill |
+| **PR process** | Title format, description gaps | `pull-request` skill |
+| **Rendering** | Layout rules, data mapping issues | `recipe-rendering` skill |
+| **User stories** | INVEST gaps, AC format | `user-stories` skill |
+| **Execution process** | Planning, verification, iteration | `execution` skill |
+| **Cross-cutting** | Applies to all tasks | `copilot-instructions.md` Working Principles |
+
+---
+
+## Step 3: Check Against Existing Knowledge
+
+Before proposing updates, verify the lesson is not already documented:
+
+1. Check `copilot-instructions.md` — Is this rule already in the 5 Rules or Working Principles?
+2. Check the relevant skill's `SKILL.md` — Is this rule already stated?
+3. Check [lessons.md](../../lessons.md) — Has this mistake been logged before?
+
+**Only propose additions for genuinely new or underemphasized patterns.**
+
+---
+
+## Step 4: Apply Updates
+
+For each new lesson:
+
+### 4a. Log in lessons.md
+
+Add an entry at the **top** of the Log section in [lessons.md](../../lessons.md):
+
+```
+### YYYY-MM-DD — Short title
+
+**What happened:** What went wrong or what was discovered.
+**Absorbed into:** File or section where the rule now lives.
+```
+
+### 4b. Update the relevant skill or instructions
+
+- **High priority** (caused broken output, wrong data, or rework): Update the skill immediately. Add a concrete prevention rule.
+- **Medium priority** (improved quality or caught a gap): Update the skill. Add to a checklist or guidelines section.
+- **Low priority** (style preference or minor improvement): Log in lessons.md only. Note for future reference.
+
+### 4c. Bump skill version
+
+If you updated a skill's `SKILL.md`, increment the version in the YAML frontmatter:
+- Minor fix/addition: `"1.0"` → `"1.1"`
+- Major restructure: `"1.1"` → `"2.0"`
+
+---
+
+## Step 5: Generate Session Summary
+
+Include this block in your **final message** to the user:
+
+```markdown
+### Session Self-Evaluation
+Lessons: [count] | Skills updated: [list or "None"] | Compacted: [files or "None"]
+```
+
+**Always include this block**, even if there's nothing to report:
+
+```markdown
+### Session Self-Evaluation
+Lessons: 0 | Skills updated: None | Compacted: None
+```
+
+This ensures the behavior is habitual, not optional.
+
+---
+
+## Anti-Patterns to Avoid
+
+1. **Don't update skills for one-off situations** — Only add patterns that are likely to recur
+2. **Don't duplicate across skills** — Each lesson goes in exactly one place
+3. **Don't restructure existing skills during self-evaluation** — Add to existing sections, don't reorganize
+4. **Don't add lessons that are standard practice** — Focus on OpenCookbook-specific patterns
+5. **Don't forget to check existing docs first** — Avoid adding what's already covered
+6. **Don't skip the summary block** — Even zero-lesson sessions get it
+
+---
+
+## Reference
+
+For examples of how lessons are captured and absorbed, see [lessons.md](../../lessons.md). Each entry shows the pattern: what happened → where the rule now lives.
+
+````


### PR DESCRIPTION
Adds two new skills for agent behavior:

- `self-evaluation`: mandatory end-of-session review with a summary block.
- `execution`: structured execution protocol (planning, verification, error handling).

Also adds a `SKILL_CREATION_GUIDE.md` to document how to author new skills, and updates `copilot-instructions.md` to reference the new skills, require a todo list, and mandate self-evaluation before finishing.
