### PR TITLE
fix(skills): remove erroneous code fences from execution and self-evaluation skills

### DIFF
--- a/.github/skills/execution/SKILL.md
+++ b/.github/skills/execution/SKILL.md
@@ -1,4 +1,3 @@
-````skill
 ---
 name: execution
 description: Autonomous execution protocol for implementing tasks. Governs planning, iteration, subagent use, verification, and self-correction. Use when executing any non-trivial implementation work — recipe edits, code changes, CI/CD updates, or multi-step tasks.
@@ -239,5 +238,3 @@ Self-evaluate (per self-evaluation skill)
     ↓
 Ship it
 ```
-
-````

--- a/.github/skills/self-evaluation/SKILL.md
+++ b/.github/skills/self-evaluation/SKILL.md
@@ -1,4 +1,3 @@
-````skill
 ---
 name: self-evaluation
 description: End-of-session self-evaluation for continuous improvement. Run before finalizing any session to capture lessons learned, identify skill updates, and improve agent effectiveness. Use when completing a task, reviewing work quality, or improving project skills.
@@ -132,5 +131,3 @@ This ensures the behavior is habitual, not optional.
 ## Reference
 
 For examples of how lessons are captured and absorbed, see [lessons.md](../../lessons.md). Each entry shows the pattern: what happened → where the rule now lives.
-
-````

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ obj/
 ## Build output
 publish/
 
+## Test results
+TestResults/
+
 ## Generated at build time — source-of-truth lives in docs/data/
 visualizer/src/OpenCookbook.Web/wwwroot/data/


### PR DESCRIPTION
## ⚠️ PR Title Check

Yes — `fix(skills): remove erroneous code fences from execution and self-evaluation skills`

## Description

The `execution` and `self-evaluation` skill files had their YAML frontmatter wrapped in ````skill` / ```` code fences, which prevented the frontmatter from being parsed and caused both skills to fail to load. The fences were removed, leaving clean `---`-delimited frontmatter matching all other skill files. Additionally, `TestResults/` was added to `.gitignore` to suppress C# unit test `.trx` output directories that were appearing as untracked files.

## Type of Change

- [x] Bug fix
- [x] Documentation / skills update

## Checklist

- [x] Skill frontmatter `description` is a single-line string (no `>` multiline)
- [x] Skill is listed in the skills table in `copilot-instructions.md`
- [x] No duplication with existing skills — detail lives in exactly one place
- [x] `dotnet build` passes locally (no code changed)

## Related Issues

None