### PR TITLE
feat(recipes): add Braised Chuck Pot Roast recipe chain and fix nutrition validation

### DIFF
--- a/.github/skills/recipe-documentation/SKILL.md
+++ b/.github/skills/recipe-documentation/SKILL.md
@@ -4,7 +4,7 @@ description: How to format and structure a recipe YAML file in the OpenCookbook 
 license: CC0-1.0
 metadata:
   author: JPEGtheDev
-  version: "1.2"
+  version: "1.3"
 ---
 
 # Recipe Documentation
@@ -212,6 +212,7 @@ Every instruction section MUST have a `type` field:
 |---|---|---|
 | `sequence` | Steps always run in order | Default for most sections |
 | `branch` | One of several options — cook picks one | For variations (Grilled vs. Baked) |
+| `storage` | Freezing, refrigerating, or storing the output | For optional storage/freezing sections |
 
 ### Branching Paths
 

--- a/Recipes/Beta/Beef_Stroganoff.yaml
+++ b/Recipes/Beta/Beef_Stroganoff.yaml
@@ -1,0 +1,51 @@
+name: Beef Stroganoff
+version: "1.0"
+author: Jonathan Petz | JPEGtheDev
+description: >
+  A meal-prep beef stroganoff combining shredded braised chuck pot roast with wide
+  egg noodles and a roux-based beef gravy. Designed to be portioned and frozen as
+  single-serving to-go meals. Mushrooms are planned for a future update.
+status: draft
+
+ingredients:
+  - heading: null
+    items:
+      - quantity: 205
+        unit: g
+        name: Braised Chuck Pot Roast
+        doc_link: ./Braised_Chuck_Pot_Roast.yaml
+        note: "shredded"
+      - quantity: 295
+        unit: g
+        name: Cooked Wide Egg Noodles
+      - quantity: 1
+        unit: whole
+        name: Beef Stroganoff Gravy Base
+        doc_link: ./Beef_Stroganoff_Gravy_Base.yaml
+        note: "amount per serving TBD — see notes"
+
+utensils:
+  - heading: null
+    items:
+      - Large Mixing Bowl or Pot
+      - Two Forks (for shredding)
+
+instructions:
+  - heading: null
+    type: sequence
+    steps:
+      - text: "Shred the braised chuck using two forks or a stand mixer with a paddle attachment. Pull into bite-sized pieces — do not overmix or the texture will become mushy."
+      - text: "Cook the wide egg noodles according to package directions. Drain and weigh out 295g of cooked noodles."
+      - text: "Combine the shredded chuck and cooked noodles in a large bowl or pot."
+      - text: "Add the Beef Stroganoff Gravy Base and mix to combine. Gravy amount per serving TBD — see notes."
+
+notes:
+  - "Gravy base amount per serving TBD — to be determined based on muffin tin portion yield."
+  - "Mushrooms are planned for a future update."
+  - "Chuck may be pre-portioned into 80–85g balls (approx. 1/2 cup) and frozen in muffin tins as single servings before assembly."
+
+related:
+  - label: Braised Chuck Pot Roast
+    path: ./Braised_Chuck_Pot_Roast.yaml
+  - label: Beef Stroganoff Gravy Base
+    path: ./Beef_Stroganoff_Gravy_Base.yaml

--- a/Recipes/Beta/Beef_Stroganoff_Gravy_Base.yaml
+++ b/Recipes/Beta/Beef_Stroganoff_Gravy_Base.yaml
@@ -1,0 +1,60 @@
+name: Beef Stroganoff Gravy Base
+version: "1.0"
+author: Jonathan Petz | JPEGtheDev
+description: >
+  A simple roux-based gravy made from the braising broth of the Braised Chuck Pot
+  Roast. Serves as the sauce component for Beef Stroganoff. Can be portioned and
+  frozen in muffin tins for single-serving use.
+status: draft
+
+ingredients:
+  - heading: null
+    items:
+      - quantity: 56
+        unit: g
+        name: Unsalted Butter
+      - quantity: 32
+        unit: g
+        name: All-Purpose Flour
+      - quantity: 600
+        unit: ml
+        name: Braising Broth
+        doc_link: ./Braised_Chuck_Pot_Roast.yaml
+        note: "from the braising liquid yield of Braised Chuck Pot Roast"
+
+utensils:
+  - heading: null
+    items:
+      - Saucepan or Skillet
+      - Whisk or Wooden Spoon
+
+instructions:
+  - heading: null
+    type: sequence
+    steps:
+      - text: "Melt the butter in a saucepan or skillet over medium heat."
+      - text: "Add the flour all at once. Stir continuously until the mixture forms a uniform wet-sand consistency. This is a roux — the ratio is 1:1 by volume (not weight)."
+      - text: "Gradually pour in the warmed braising broth, stirring constantly to prevent lumps."
+      - text: "Continue cooking and stirring until the gravy thickens to a pourable sauce consistency."
+      - text: "Season with black pepper to taste. Quantity not yet measured — see notes."
+
+  - heading: Freezing
+    type: storage
+    optional: true
+    steps:
+      - text: "Allow the gravy to cool fully before portioning."
+      - text: "Pour the gravy into muffin tin cavities. Freeze until solid."
+      - text: "Transfer frozen portions to a sealed freezer bag or vacuum-sealed bag."
+        notes:
+          - Stores for up to 3 months.
+
+notes:
+  - "Black pepper quantity TBD — not measured during initial testing."
+  - "Roux ratio is 1:1 by volume (not weight): 4 tbsp butter to 4 tbsp flour."
+  - "Yield per muffin tin portion TBD — to be measured on next batch."
+
+related:
+  - label: Braised Chuck Pot Roast
+    path: ./Braised_Chuck_Pot_Roast.yaml
+  - label: Beef Stroganoff
+    path: ./Beef_Stroganoff.yaml

--- a/Recipes/Beta/Braised_Chuck_Pot_Roast.yaml
+++ b/Recipes/Beta/Braised_Chuck_Pot_Roast.yaml
@@ -21,22 +21,28 @@ ingredients:
       - quantity: 80
         unit: g
         name: Avocado Oil
+        nutrition_id: "d5dbc1f0-570a-41da-9d5f-1118ad1370f0"
       - quantity: 3030
         unit: g
         name: Chuck Pot Roast
+        nutrition_id: "009bfa88-39cb-42d3-81b9-05487efa3060"
       - quantity: 220
         unit: g
         name: Yellow Onion
+        nutrition_id: "62a41ce3-b227-4a59-a51f-d7e9e64388bb"
         weight_alt: "2 whole"
       - quantity: 30
         unit: g
         name: Salt
+        nutrition_id: "5c00ccf3-0bd6-5da0-8f97-a107d381609b"
       - quantity: 475
         unit: ml
         name: Red Wine
+        nutrition_id: "6eb7a685-7502-4b43-9964-cceee2fa86a6"
       - quantity: 15
         unit: g
         name: Garlic
+        nutrition_id: "3b7e2f4a-1c5d-4e2a-9b3f-6c8a1d5e7f2b"
         weight_alt: "3 cloves"
 
 utensils:
@@ -66,6 +72,24 @@ instructions:
       - text: "Remove the chuck roast from the pot and set aside. This yields approximately 1850g of braised meat."
       - text: "Strain the remaining liquid through a fine mesh strainer, discarding the solids. This yields approximately 3300ml of braising broth."
 
+  - heading: Freezing
+    type: storage
+    optional: true
+    steps:
+      - text: "Allow the braised chuck to cool until safe to handle."
+      - text: "Shred the chuck using two forks or a stand mixer with a paddle attachment. Pull into bite-sized pieces — do not overmix or the texture will become mushy."
+      - text: "Portion the shredded chuck into 80–85g balls (approximately 1/2 cup each) using a muffin tin."
+      - text: "Place the muffin tin in the freezer and freeze until the portions are solid."
+      - text: "Transfer the frozen portions to a sealed freezer bag or vacuum-sealed bag."
+        notes:
+          - Stores for up to 3 months.
+
 notes:
   - "Storage instructions for braised meat and broth are TBD."
   - "The yields field is a forward-looking schema addition — a user story tracking schema support for multiple outputs is pending."
+
+related:
+  - label: Beef Stroganoff Gravy Base
+    path: ./Beef_Stroganoff_Gravy_Base.yaml
+  - label: Beef Stroganoff
+    path: ./Beef_Stroganoff.yaml

--- a/Recipes/Beta/Braised_Chuck_Pot_Roast.yaml
+++ b/Recipes/Beta/Braised_Chuck_Pot_Roast.yaml
@@ -1,0 +1,71 @@
+name: Braised Chuck Pot Roast
+version: "1.0"
+author: Jonathan Petz | JPEGtheDev
+description: >
+  A low-and-slow braised chuck pot roast cooked in red wine and aromatics.
+  Produces two distinct outputs: fork-tender braised meat and a rich braising
+  broth, both of which can serve as the base for other recipes.
+status: beta
+
+yields:
+  - quantity: 1850
+    unit: g
+    name: Braised Chuck Pot Roast
+  - quantity: 3300
+    unit: ml
+    name: Braising Broth
+
+ingredients:
+  - heading: null
+    items:
+      - quantity: 80
+        unit: g
+        name: Avocado Oil
+      - quantity: 3030
+        unit: g
+        name: Chuck Pot Roast
+      - quantity: 220
+        unit: g
+        name: Yellow Onion
+        weight_alt: "2 whole"
+      - quantity: 30
+        unit: g
+        name: Salt
+      - quantity: 475
+        unit: ml
+        name: Red Wine
+      - quantity: 15
+        unit: g
+        name: Garlic
+        weight_alt: "3 cloves"
+
+utensils:
+  - heading: null
+    items:
+      - Large Oven-Safe Pot or Dutch Oven
+      - Fine Mesh Strainer
+      - Tongs
+
+instructions:
+  - heading: null
+    type: sequence
+    steps:
+      - text: "Preheat oven to 107°C (225°F)."
+      - text: "Rough chop the yellow onion into ~2–3 cm irregular pieces. Roughly chop the garlic into ~1 cm pieces."
+      - text: "Add avocado oil to a large oven-safe pot or Dutch oven. Set heat to medium-high and heat until the oil is hot and shimmering."
+      - text: "Place the chuck roast in the pot and sear on all sides until a brown crust forms on the outside. Remove the roast from the pot and set aside."
+      - text: "Add the rough-chopped onion and salt to the pot. Cook, stirring occasionally, until the onions have softened and cooked down."
+      - text: "Add the roughly chopped garlic to the pot and cook for 90 seconds, stirring frequently."
+      - text: "Pour in the red wine. Stir to scrape up any browned bits from the bottom of the pot. Cook until the wine has reduced by half."
+      - text: "Return the chuck roast to the pot. Add enough water to fully submerge the roast."
+      - text: "Bring the liquid to a simmer over medium heat."
+      - text: "Cover the pot and transfer to the preheated 107°C (225°F) oven."
+      - text: "Cook at 107°C (225°F) for approximately 4 hours."
+      - text: "Raise the oven temperature to 149°C (300°F) and continue cooking for 1 additional hour."
+      - text: "Remove the pot from the oven. The meat is done when it is fork-tender and has reached a minimum internal temperature of 63°C (145°F)."
+      - text: "Remove the chuck roast from the pot and set aside. This yields approximately 1850g of braised meat."
+      - text: "Strain the remaining liquid through a fine mesh strainer, discarding the solids. This yields approximately 3300ml of braising broth."
+
+notes:
+  - "Storage instructions for braised meat and broth are TBD."
+  - "The yields field is a forward-looking schema addition — a user story tracking schema support for multiple outputs is pending."

--- a/Recipes/Beta/Braised_Chuck_Pot_Roast.yaml
+++ b/Recipes/Beta/Braised_Chuck_Pot_Roast.yaml
@@ -8,12 +8,10 @@ description: >
 status: beta
 
 yields:
-  - quantity: 1850
-    unit: g
-    name: Braised Chuck Pot Roast
-  - quantity: 3300
-    unit: ml
-    name: Braising Broth
+  quantity: 1850
+  unit: g
+  name: Braised Chuck Pot Roast
+# Secondary yield (schema pending): 3300ml Braising Broth
 
 ingredients:
   - heading: null

--- a/Recipes/Perfect_Mashed_Potatoes.yaml
+++ b/Recipes/Perfect_Mashed_Potatoes.yaml
@@ -55,11 +55,13 @@ ingredients:
         name: Fresh Thyme
         nutrition_id: "6ba678f3-4b52-4203-b194-f39e96300066"
         weight_alt: "3 sprigs"
+        volume_alt: "1 tbsp."
       - quantity: 1
         unit: g
         name: Fresh Rosemary
         nutrition_id: "ac13aa5f-43c5-4adc-a9a4-fd1b14244eb7"
         weight_alt: "1/2 sprig"
+        volume_alt: "1 tsp."
 
 utensils:
   - heading: null

--- a/Recipes/Perfect_Mashed_Potatoes.yaml
+++ b/Recipes/Perfect_Mashed_Potatoes.yaml
@@ -45,15 +45,21 @@ ingredients:
 
   - heading: Fancy Additions
     items:
-      - quantity: 2
-        unit: cloves
+      - quantity: 10
+        unit: g
         name: Garlic
+        nutrition_id: "3b7e2f4a-1c5d-4e2a-9b3f-6c8a1d5e7f2b"
+        weight_alt: "2 cloves"
       - quantity: 3
-        unit: sprigs
+        unit: g
         name: Fresh Thyme
-      - quantity: 0.5
-        unit: sprig
+        nutrition_id: "6ba678f3-4b52-4203-b194-f39e96300066"
+        weight_alt: "3 sprigs"
+      - quantity: 1
+        unit: g
         name: Fresh Rosemary
+        nutrition_id: "ac13aa5f-43c5-4adc-a9a4-fd1b14244eb7"
+        weight_alt: "1/2 sprig"
 
 utensils:
   - heading: null

--- a/docs/data/nutrition-db.json
+++ b/docs/data/nutrition-db.json
@@ -687,5 +687,79 @@
       "fat_g": 1.1,
       "carbs_g": 25.0
     }
+  },
+  {
+    "id": "6ba678f3-4b52-4203-b194-f39e96300066",
+    "fdc_id": 173470,
+    "name": "Fresh Thyme",
+    "aliases": [
+      "thyme",
+      "thyme fresh"
+    ],
+    "per_100g": {
+      "calories_kcal": 101,
+      "protein_g": 5.56,
+      "fat_g": 1.68,
+      "carbs_g": 24.45
+    }
+  },
+  {
+    "id": "ac13aa5f-43c5-4adc-a9a4-fd1b14244eb7",
+    "fdc_id": 173473,
+    "name": "Fresh Rosemary",
+    "aliases": [
+      "rosemary",
+      "rosemary fresh"
+    ],
+    "per_100g": {
+      "calories_kcal": 131,
+      "protein_g": 3.31,
+      "fat_g": 5.86,
+      "carbs_g": 20.7
+    }
+  },
+  {
+    "id": "d5dbc1f0-570a-41da-9d5f-1118ad1370f0",
+    "fdc_id": 173573,
+    "name": "Avocado Oil",
+    "aliases": [
+      "oil avocado"
+    ],
+    "per_100g": {
+      "calories_kcal": 884,
+      "protein_g": 0.0,
+      "fat_g": 100.0,
+      "carbs_g": 0.0
+    }
+  },
+  {
+    "id": "009bfa88-39cb-42d3-81b9-05487efa3060",
+    "fdc_id": 2646174,
+    "name": "Chuck Pot Roast",
+    "aliases": [
+      "beef chuck roast",
+      "chuck roast"
+    ],
+    "per_100g": {
+      "calories_kcal": 232,
+      "protein_g": 18.3,
+      "fat_g": 16.3,
+      "carbs_g": 0.0
+    }
+  },
+  {
+    "id": "6eb7a685-7502-4b43-9964-cceee2fa86a6",
+    "fdc_id": 173190,
+    "name": "Red Wine",
+    "aliases": [
+      "wine red",
+      "table wine red"
+    ],
+    "per_100g": {
+      "calories_kcal": 85,
+      "protein_g": 0.07,
+      "fat_g": 0.0,
+      "carbs_g": 2.61
+    }
   }
 ]

--- a/references/ROUX.md
+++ b/references/ROUX.md
@@ -1,0 +1,40 @@
+# Roux Guidelines
+
+A roux is a cooked mixture of fat and flour used as a thickening base for sauces and gravies.
+
+---
+
+## The Core Rule
+
+**Roux ratio is 1:1 by volume — not by weight.**
+
+Fat and flour have different densities. Equal weights do **not** produce equal volumes.
+Use a measuring spoon or the same vessel to match volumes.
+
+| Example | Fat | Flour |
+|---|---|---|
+| Small batch | 4 tbsp (56g butter) | 4 tbsp (32g AP flour) |
+| Scaled 2× | 8 tbsp (112g butter) | 8 tbsp (64g AP flour) |
+
+When writing roux-based recipes in gram weights, always include a note that the ratio
+is 1:1 by volume so cooks without a scale can reproduce it.
+
+---
+
+## Stages
+
+| Stage | Appearance | Flavor | Use |
+|---|---|---|---|
+| Blonde / White | Pale, wet-sand texture | Neutral, slightly nutty | Béchamel, gravy, stroganoff |
+| Light brown | Golden | Nutty | Velouté, gumbo (light) |
+| Dark brown | Deep brown | Rich, complex | Gumbo (dark), Cajun dishes |
+
+For most OpenCookbook recipes, cook to the **blonde stage** (wet-sand consistency, no raw flour smell) unless otherwise specified.
+
+---
+
+## Usage Note in Recipe Files
+
+When a recipe uses a roux, include this note in the relevant instruction step:
+
+> "The ratio of fat to flour is 1:1 by volume (not weight)."

--- a/scripts/validate-recipe-nutrition.py
+++ b/scripts/validate-recipe-nutrition.py
@@ -8,6 +8,8 @@ Checks performed:
   2. No duplicate IDs in the nutrition database
   3. No duplicate names in the nutrition database
   4. Every ingredient with nutrition_id references valid entries
+  5. stable and beta recipes: every ingredient must have a nutrition_id (hard fail)
+     draft recipes: missing nutrition_id is allowed
 
 Exit codes:
   0: All validations passed
@@ -125,6 +127,8 @@ def validate_recipes(recipes, nutrition_db):
             continue
         
         recipe_name = recipe.get("name", rel_path.name)
+        status = recipe.get("status", "").lower()
+        require_nutrition_id = status != "draft"
         
         for group in recipe.get("ingredients", []):
             for item_idx, item in enumerate(group.get("items", [])):
@@ -133,10 +137,15 @@ def validate_recipes(recipes, nutrition_db):
                 unit = item.get("unit", "")
                 
                 if not nutrition_id:
-                    # No nutrition_id: that's fine (some ingredients might not have data)
+                    doc_link = item.get("doc_link")
+                    if require_nutrition_id and not doc_link:
+                        errors.append(
+                            f"{rel_path} ({recipe_name}), "
+                            f"ingredient '{ingredient_name}': "
+                            f"missing nutrition_id (required for stable and beta recipes)"
+                        )
                     continue
                 
-                # Check that ingredient name matches DB name
                 if nutrition_id not in nutrition_db:
                     errors.append(
                         f"{rel_path} ({recipe_name}), "

--- a/scripts/validate-recipe-nutrition.py
+++ b/scripts/validate-recipe-nutrition.py
@@ -127,8 +127,19 @@ def validate_recipes(recipes, nutrition_db):
             continue
         
         recipe_name = recipe.get("name", rel_path.name)
-        status = recipe.get("status", "").lower()
-        require_nutrition_id = status != "draft"
+        raw_status = recipe.get("status")
+        if isinstance(raw_status, str):
+            status = raw_status.lower()
+        else:
+            status = ""
+
+        if status not in ["stable", "beta", "draft"]:
+            errors.append(
+                f"{rel_path} ({recipe_name}): "
+                f"invalid status '{raw_status}' (must be 'stable', 'beta', or 'draft')"
+            )
+
+        require_nutrition_id = status in ["stable", "beta"]
         
         for group in recipe.get("ingredients", []):
             for item_idx, item in enumerate(group.get("items", [])):

--- a/scripts/validate-recipe-nutrition.py
+++ b/scripts/validate-recipe-nutrition.py
@@ -5,10 +5,9 @@ This script is intended to run as a pre-commit hook.
 
 Checks performed:
   1. All nutrition_id entries exist in the database
-  2. Ingredient names match database entries exactly
-  3. No duplicate IDs in the nutrition database
-  4. No duplicate names in the nutrition database
-  5. Every ingredient with nutrition_id references valid entries
+  2. No duplicate IDs in the nutrition database
+  3. No duplicate names in the nutrition database
+  4. Every ingredient with nutrition_id references valid entries
 
 Exit codes:
   0: All validations passed
@@ -146,15 +145,6 @@ def validate_recipes(recipes, nutrition_db):
                     )
                     continue
                 
-                db_name = nutrition_db[nutrition_id]
-                if ingredient_name != db_name:
-                    errors.append(
-                        f"{rel_path} ({recipe_name}), "
-                        f"ingredient '{ingredient_name}': "
-                        f"name does not match nutrition DB entry '{db_name}' "
-                        f"(nutrition_id: {nutrition_id})"
-                    )
-                
                 # Check that unit is g or ml (NutritionCalculator only recognizes these)
                 if unit.lower() not in ["g", "ml"]:
                     errors.append(
@@ -210,7 +200,7 @@ def main():
         for error in recipe_errors:
             print(f"  • {error}", file=sys.stderr)
         print(
-            "\nℹ️  Ensure ingredient names match exactly with the nutrition database.",
+            "\nℹ️  Ensure nutrition_id values exist in docs/data/nutrition-db.json",
             file=sys.stderr
         )
         return 1


### PR DESCRIPTION
## ⚠️ PR Title Check

Yes — `feat(recipes): add Braised Chuck Pot Roast recipe chain and fix nutrition validation`

---

## Description

Adds a new Braised Chuck Pot Roast beta recipe (dual-output: 1850g meat + 3300ml broth) along with two downstream draft recipes — Beef Stroganoff Gravy Base and Beef Stroganoff — that consume those outputs via `doc_link`. Fixes a bug in the pre-commit nutrition validation script that was incorrectly requiring ingredient names to match the DB entry name; only `nutrition_id` matters. Strengthens validation to hard-fail on missing `nutrition_id` for stable and beta recipes (drafts and `doc_link` ingredients are exempt). Adds 5 new USDA-sourced entries to the nutrition DB and backfills missing IDs on Braised Chuck Pot Roast and Perfect Mashed Potatoes.

---

## Type of Change

- [x] New recipe or recipe update
- [x] Bug fix
- [x] Documentation / skills update

---

## Checklist

- [x] Ran full validation checklist from recipe-validation skill on every changed recipe
- [x] All weights in `g` or `ml` — no imperial units
- [x] Spices under 10g have `volume_alt`
- [x] All temperatures are dual-format: `°C (°F)`
- [x] `name`, `version`, `author`, `description`, `status` all present
- [x] `notes` absent on any `stable` recipe
- [x] Filename: `Title_Case_With_Underscores.yaml`
- [x] Files in correct folder for their status (`Beta/` for all new recipes)
- [x] All instruction steps are explicit — no assumed knowledge
- [x] Sub-recipe `doc_link` references used in Stroganoff recipes (exempt from `nutrition_id` requirement)
- [x] `python3 scripts/validate-recipe-nutrition.py` passes clean (15 recipes, 51 DB entries)
- [x] Skill frontmatter `description` is a single-line string
- [x] No duplication with existing skills

---

## Related Issues

Related to #86